### PR TITLE
if you want to use your custom ftp handler for event callbacks. Custom h...

### DIFF
--- a/src/django_ftpserver/management/commands/ftpserver.py
+++ b/src/django_ftpserver/management/commands/ftpserver.py
@@ -101,13 +101,13 @@ class Command(BaseCommand):
             or utils.get_settings_value('FTPSERVER_SENDFILE')
             
         # custom handler
-        custom_handler = utils.get_settings_value('FTPSERVER_CUSTOM_HANDLER')
+        custom_handler = utils.get_ftp_handler(utils.get_settings_value('FTPSERVER_CUSTOM_HANDLER'))
 
         if custom_handler == None:
             custom_handler = handlers.FTPHandler
             
         # custom tls handler
-        custom_tls_handler = utils.get_settings_value('FTPSERVER_CUSTOM_TLS_HANDLER')
+        custom_tls_handler = utils.get_ftp_handler(utils.get_settings_value('FTPSERVER_CUSTOM_TLS_HANDLER'))
 
         if custom_tls_handler == None:
             custom_tls_handler = handlers.TLS_FTPHandler

--- a/src/django_ftpserver/utils.py
+++ b/src/django_ftpserver/utils.py
@@ -44,3 +44,17 @@ def make_server(
         setattr(handler, key, value)
     handler.authorizer = authorizer
     return server_class(host_port, handler)
+    
+def get_ftp_handler(handler):
+    """
+    Custom handler if include models and import in settings, 
+    problem for django...
+    """
+    if handler == None:
+        return None
+        
+    base_dir = getattr(settings, 'BASE_DIR', None)
+    module = __import__(handler.rsplit('.', 1)[0], fromlist=[base_dir])
+    print module
+    class_ = getattr(module, handler.rsplit('.', 1)[1], None)
+    return class_


### PR DESCRIPTION
some times you need to custom ftp handlers. for example file was received triggered a even for special purposes.

But only use your django settings file. command line options cannot run for custom handler. 
