### PR TITLE
custom ftphandler set in settings file

### DIFF
--- a/src/django_ftpserver/management/commands/ftpserver.py
+++ b/src/django_ftpserver/management/commands/ftpserver.py
@@ -101,13 +101,13 @@ class Command(BaseCommand):
             or utils.get_settings_value('FTPSERVER_SENDFILE')
             
         # custom handler
-        custom_handler = utils.get_settings_value('FTPSERVER_CUSTOM_HANDLER')
+        custom_handler = utils.get_ftp_handler(utils.get_settings_value('FTPSERVER_CUSTOM_HANDLER'))
 
         if custom_handler == None:
             custom_handler = handlers.FTPHandler
             
         # custom tls handler
-        custom_tls_handler = utils.get_settings_value('FTPSERVER_CUSTOM_TLS_HANDLER')
+        custom_tls_handler = utils.get_ftp_handler(utils.get_settings_value('FTPSERVER_CUSTOM_TLS_HANDLER'))
 
         if custom_tls_handler == None:
             custom_tls_handler = handlers.TLS_FTPHandler

--- a/src/django_ftpserver/utils.py
+++ b/src/django_ftpserver/utils.py
@@ -44,3 +44,17 @@ def make_server(
         setattr(handler, key, value)
     handler.authorizer = authorizer
     return server_class(host_port, handler)
+    
+def get_ftp_handler(handler):
+    """
+    Custom handler if include models and import in settings, 
+    problem for django...
+    """
+    if handler == None:
+        return None
+        
+    base_dir = getattr(settings, 'BASE_DIR', None)
+    module = __import__(handler.rsplit('.', 1)[0], fromlist=[base_dir])
+    print module
+    class_ = getattr(module, handler.rsplit('.', 1)[1], None)
+    return class_


### PR DESCRIPTION
For custom purpose custom ftphandler setting in django settings file
# Django FTPSERVER settings

FTPSERVER_HOST = '127.0.0.1'
# FTPSERVER_HOST = '0.0.0.0'

FTPSERVER_PORT = '10021'
FTPSERVER_PASSIVE_PORTS = '10025'
# FTP handler settings

FTPSERVER_CUSTOM_HANDLER = 'ftp_utils.handlers.QloudEncodeFtpEventHandler'
# ftp deamonize settings

FTPSERVER_DAEMONIZE = False

ftp_utils.handlers.QloudEncodeFtpEventHandler ftphandler extends FTPHandler. Some ftp event tapping in this custom handler. for example file_complete_recieved function triggered file successfully transferred. Your handler is trap this event for do anything.
