### PR TITLE
Fix for python3 in utils

### DIFF
--- a/src/django_ftpserver/utils.py
+++ b/src/django_ftpserver/utils.py
@@ -1,5 +1,11 @@
 from django.conf import settings
 
+# compatability
+try:
+    basestring
+except NameError:
+    basestring = str
+
 
 def get_settings_value(name):
     """Return the django settings value for name attribute


### PR DESCRIPTION
The builtin basestring abstract type is removed in python 3.