### PR TITLE
Remove Python 3.10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v5

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -8,6 +8,7 @@ Change History
 
 * Added Django 6.1 support
 * Removed Django 4.2, 5.0, 5.1 support
+* Removed Python 3.10 support (EOL 2026-10-31)
 
 1.0.0
 =====

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Optional dependencies can be installed with extras:
 Requirements
 ============
 
-* Target Python version is 3.10, 3.11, 3.12, 3.13, 3.14
+* Target Python version is 3.11, 3.12, 3.13, 3.14
 * Django>=5.2
 * pyftpdlib
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,12 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
+requires-python = ">=3.11"
 dependencies = [
     "Django>=5.2",
     "pyftpdlib",
@@ -51,7 +51,7 @@ pythonpath = ["tests/django_project"]
 DJANGO_SETTINGS_MODULE = "project.settings"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "W"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{310,311,312,313,314}-dj52,
+  py{311,312,313,314}-dj52,
   py{312,313,314}-dj60,
   py{312,313,314}-dj61,
   coverage,
@@ -8,7 +8,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.10: py310
     3.11: py311
     3.12: py312, ruff
     3.13: py313


### PR DESCRIPTION
Python 3.10 reaches end of life on 2026-10-31, so this drops it from the supported version matrix.

## Support status review

| Version | Status | Action |
| --- | --- | --- |
| Python 3.10 | EOL 2026-10-31 | **Removed** |
| Python 3.11 – 3.14 | Supported | Kept |
| Django 5.2 LTS | Extended support through 2028-04 | Kept |
| Django 6.0 | Security support through 2027-04 | Kept |
| Django 6.1 | Current | Kept |

No Django version currently in the matrix has reached end of life, so the Django matrix is unchanged.

## Changes

* `pyproject.toml` — drop the `Programming Language :: Python :: 3.10` classifier and add `requires-python = ">=3.11"` so pip refuses to install on unsupported interpreters. This key was previously absent, so the package could be installed on any interpreter regardless of the declared classifiers.
* `pyproject.toml` — bump `[tool.ruff] target-version` to `py311`.
* `tox.ini` — drop `py310` from the envlist and from the `[gh-actions]` mapping.
* `.github/workflows/tests.yml` — drop `'3.10'` from the test matrix.
* `README.rst` — update the target Python versions listed under Requirements.
* `ChangeLog.rst` — add the removal to the 1.1.0 entry.

The ChangeLog note was added to the existing 1.1.0 section rather than opening a new one, since there is no `v1.1.0` tag yet and that release is still unreleased. Happy to split it into a 1.2.0 section instead if you would rather treat 1.1.0 as closed.

## Verification

* `ruff check` and `ruff format --check` pass on `django_ftpserver/`, `tests/` and `example/`.
* `pytest` on Python 3.11 with Django 5.2: 144 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015o3Khu62xf47zXetHinob4

---
_Generated by [Claude Code](https://claude.ai/code/session_015o3Khu62xf47zXetHinob4)_